### PR TITLE
feat: Add onboarding flow with PM-first game progression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
         "@codesandbox/sandpack-react": "^2.20.0",
         "@git-diff-view/lowlight": "^0.0.35",
         "@git-diff-view/react": "^0.0.35",
-        "@mastra/core": "^0.24.9",
-        "@mastra/memory": "^0.15.13",
-        "@mastra/server": "^0.24.9",
+        "@mastra/core": "beta",
+        "@mastra/memory": "beta",
+        "@mastra/server": "beta",
         "better-auth": "^1.4.10",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
@@ -24,6 +24,8 @@
         "postgres": "^3.4.7",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^7.11.0",
+        "serve": "^14.2.5",
         "uuid": "^11.0.0",
         "zod": "^3.25.76",
         "zustand": "^5.0.0"
@@ -6610,6 +6612,12 @@
       "integrity": "sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==",
       "license": "MIT"
     },
+    "node_modules/@zeit/schemas": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
+      "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -6760,6 +6768,15 @@
       "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
       "license": "MIT"
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -6783,6 +6800,32 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -6857,7 +6900,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -7094,11 +7136,123 @@
         }
       }
     },
+    "node_modules/boxen": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
+      "integrity": "sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^7.0.0",
+        "chalk": "^5.0.1",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^5.1.2",
+        "type-fest": "^2.13.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/boxen/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7230,6 +7384,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001727",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
@@ -7265,7 +7431,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -7276,6 +7441,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -7289,6 +7469,35 @@
       "resolved": "https://registry.npmjs.org/clean-set/-/clean-set-1.1.2.tgz",
       "integrity": "sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==",
       "license": "MIT"
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+      "license": "MIT",
+      "dependencies": {
+        "arch": "^2.2.0",
+        "execa": "^5.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -7346,11 +7555,64 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concurrently": {
@@ -7464,7 +7726,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -7598,6 +7859,15 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -7833,6 +8103,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -8287,6 +8563,29 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -8365,7 +8664,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -8666,6 +8964,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
@@ -8737,7 +9047,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8924,6 +9233,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
@@ -9025,6 +9343,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/intersection-observer": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.10.0.tgz",
@@ -9054,6 +9378,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extglob": {
@@ -9110,6 +9449,18 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-port-reachable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-4.0.0.tgz",
+      "integrity": "sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -9135,11 +9486,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -9585,6 +9947,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -9655,6 +10023,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -9669,7 +10046,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -9803,6 +10179,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -9856,6 +10244,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -9863,6 +10260,21 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/openai": {
@@ -10021,11 +10433,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
+      "license": "(WTFPL OR MIT)"
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10458,7 +10875,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10539,6 +10955,30 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -10583,6 +11023,57 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.11.0.tgz",
+      "integrity": "sha512-uI4JkMmjbWCZc01WVP2cH7ZfSzH91JAZUDd7/nIprDgWxBV1TkkmLToFh7EbMTcMak8URFRa2YoBL/W8GWnCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.11.0.tgz",
+      "integrity": "sha512-e49Ir/kMGRzFOOrYQBdoitq3ULigw4lKbAyKusnvtDu2t4dBX4AGYPrzNvorXmVuOyeakai6FUPW5MmibvVG8g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.11.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/reactivity-store": {
@@ -10638,6 +11129,28 @@
         "node": ">= 18"
       }
     },
+    "node_modules/registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10651,7 +11164,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10931,6 +11443,100 @@
         }
       }
     },
+    "node_modules/serve": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.5.tgz",
+      "integrity": "sha512-Qn/qMkzCcMFVPb60E/hQy+iRLpiU8PamOfOSYoAHmmF+fFFmpPpqa6Oci2iWYpTdOUM3VF+TINud7CfbQnsZbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zeit/schemas": "2.36.0",
+        "ajv": "8.12.0",
+        "arg": "5.0.2",
+        "boxen": "7.0.0",
+        "chalk": "5.0.1",
+        "chalk-template": "0.4.0",
+        "clipboardy": "3.0.0",
+        "compression": "1.8.1",
+        "is-port-reachable": "4.0.0",
+        "serve-handler": "6.1.6",
+        "update-check": "1.5.4"
+      },
+      "bin": {
+        "serve": "build/main.js"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/serve-handler": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.6.tgz",
+      "integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "mime-types": "2.1.18",
+        "minimatch": "3.1.2",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "3.3.0",
+        "range-parser": "1.2.0"
+      }
+    },
+    "node_modules/serve-handler/node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-handler/node_modules/content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "~1.33.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "license": "MIT"
+    },
+    "node_modules/serve-handler/node_modules/range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/serve-static": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
@@ -10950,6 +11556,40 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/serve/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/serve/node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/serve/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
@@ -10966,7 +11606,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10979,7 +11618,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11081,6 +11719,12 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/sonic-boom": {
@@ -11211,6 +11855,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -11247,7 +11900,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -12004,6 +12656,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -12108,11 +12772,20 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/update-check": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.4.tgz",
+      "integrity": "sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -12409,7 +13082,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -12436,6 +13108,71 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/word-wrap": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,11 @@ import {
   AuthScreen,
   StartScreen,
   ProjectsScreen,
+  // Onboarding flow screens
+  HirePMScreen,
+  IdeateScreen,
+  HireEngineerScreen,
+  // Main game screens
   HireScreen, 
   TasksScreen,
   TeamScreen,
@@ -44,6 +49,39 @@ function RequireProject({ children }: { children: React.ReactNode }) {
   
   if (!project) {
     return <Navigate to="/start" replace />;
+  }
+  return <>{children}</>;
+}
+
+/**
+ * PhaseRouter - Routes to the correct screen based on game phase
+ * Used for the onboarding flow
+ */
+function PhaseRouter() {
+  const phase = useGameStore(state => state.phase);
+  
+  switch (phase) {
+    case 'hire_pm':
+      return <HirePMScreen />;
+    case 'ideate':
+      return <IdeateScreen />;
+    case 'hire_engineer':
+      return <HireEngineerScreen />;
+    case 'playing':
+    default:
+      // If in playing phase, redirect to main game
+      return <Navigate to="/play" replace />;
+  }
+}
+
+/**
+ * PlayingPhaseGuard - Redirects to onboarding if not in playing phase
+ */
+function PlayingPhaseGuard({ children }: { children: React.ReactNode }) {
+  const phase = useGameStore(state => state.phase);
+  
+  if (phase !== 'playing') {
+    return <Navigate to="/play/onboarding" replace />;
   }
   return <>{children}</>;
 }
@@ -283,12 +321,24 @@ function App() {
             element={isAuthenticated ? <ProjectsScreen /> : <Navigate to="/login?redirect=/projects" replace />} 
           />
           
-          {/* Game routes - require active project */}
+          {/* Onboarding flow routes - phase-specific screens */}
+          <Route 
+            path="/play/onboarding/*" 
+            element={
+              <RequireProject>
+                <PhaseRouter />
+              </RequireProject>
+            }
+          />
+          
+          {/* Game routes - require active project and playing phase */}
           <Route 
             path="/play" 
             element={
               <RequireProject>
-                <GameLayout />
+                <PlayingPhaseGuard>
+                  <GameLayout />
+                </PlayingPhaseGuard>
               </RequireProject>
             }
           >

--- a/src/components/screens/HireEngineerScreen.css
+++ b/src/components/screens/HireEngineerScreen.css
@@ -1,0 +1,344 @@
+/* Hire Engineer Screen - Second gate after ideation */
+
+.hire-engineer-screen {
+  min-height: 100vh;
+  background: #050508;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.hire-engineer-container {
+  width: 100%;
+  max-width: 600px;
+}
+
+/* Progress Steps */
+.progress-steps {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 40px;
+}
+
+.step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.step-icon {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 50%;
+  font-size: 12px;
+  font-weight: 600;
+  color: #52525b;
+}
+
+.step.completed .step-icon {
+  background: rgba(0, 255, 136, 0.15);
+  border-color: rgba(0, 255, 136, 0.3);
+  color: #00ff88;
+}
+
+.step.active .step-icon {
+  background: #00ff88;
+  border-color: #00ff88;
+  color: #000;
+}
+
+.step-label {
+  font-size: 11px;
+  color: #52525b;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.step.completed .step-label,
+.step.active .step-label {
+  color: #a1a1aa;
+}
+
+.step-line {
+  width: 40px;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.1);
+  margin: 0 12px;
+  margin-bottom: 20px;
+}
+
+.step-line.completed {
+  background: rgba(0, 255, 136, 0.3);
+}
+
+/* Main Content */
+.hire-engineer-content {
+  text-align: center;
+}
+
+.hire-engineer-content h1 {
+  margin: 0 0 12px 0;
+  font-size: 28px;
+  font-weight: 600;
+  color: #e4e4e7;
+}
+
+.hire-engineer-content .subtitle {
+  margin: 0 0 32px 0;
+  font-size: 15px;
+  color: #71717a;
+  line-height: 1.6;
+}
+
+/* Engineer Card */
+.engineer-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  margin-bottom: 24px;
+  text-align: left;
+}
+
+.engineer-icon {
+  width: 56px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 14px;
+  font-size: 24px;
+  color: #3b82f6;
+  flex-shrink: 0;
+}
+
+.engineer-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.engineer-info h3 {
+  margin: 0 0 6px 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #e4e4e7;
+}
+
+.engineer-info p {
+  margin: 0 0 14px 0;
+  font-size: 14px;
+  color: #71717a;
+  line-height: 1.5;
+}
+
+.engineer-details {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.engineer-salary {
+  font-size: 16px;
+  font-weight: 600;
+  color: #e4e4e7;
+}
+
+.engineer-budget {
+  font-size: 13px;
+  color: #52525b;
+}
+
+.hire-engineer-btn {
+  padding: 14px 28px;
+  background: #3b82f6;
+  border: none;
+  border-radius: 10px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.hire-engineer-btn:hover:not(.disabled) {
+  background: #2563eb;
+  transform: translateY(-1px);
+}
+
+.hire-engineer-btn.disabled {
+  background: rgba(255, 255, 255, 0.1);
+  color: #52525b;
+  cursor: not-allowed;
+}
+
+/* Task Preview */
+.task-preview {
+  padding: 20px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  margin-bottom: 20px;
+  text-align: left;
+}
+
+.preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.preview-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #52525b;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.preview-count {
+  font-size: 12px;
+  padding: 4px 10px;
+  background: rgba(0, 255, 136, 0.1);
+  border-radius: 4px;
+  color: #00ff88;
+}
+
+.preview-tasks {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.preview-task {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.task-dot {
+  width: 6px;
+  height: 6px;
+  background: #00ff88;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.task-title {
+  font-size: 13px;
+  color: #a1a1aa;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preview-more {
+  font-size: 12px;
+  color: #52525b;
+  margin-left: 16px;
+}
+
+/* Team Status */
+.team-status {
+  padding: 16px 20px;
+  background: rgba(0, 255, 136, 0.04);
+  border: 1px solid rgba(0, 255, 136, 0.1);
+  border-radius: 10px;
+}
+
+.team-member {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.member-icon {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 255, 136, 0.1);
+  border: 1px solid rgba(0, 255, 136, 0.2);
+  border-radius: 8px;
+  font-size: 14px;
+  color: #00ff88;
+}
+
+.member-name {
+  flex: 1;
+  font-size: 14px;
+  color: #e4e4e7;
+}
+
+.member-status {
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.member-status.ready {
+  background: rgba(0, 255, 136, 0.1);
+  color: #00ff88;
+}
+
+/* Modal styles inherit from HireScreen.css */
+
+/* Responsive */
+@media (max-width: 640px) {
+  .hire-engineer-screen {
+    padding: 16px;
+    align-items: flex-start;
+    padding-top: 40px;
+  }
+
+  .progress-steps {
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 32px;
+  }
+
+  .step-line {
+    display: none;
+  }
+
+  .hire-engineer-content h1 {
+    font-size: 22px;
+  }
+
+  .engineer-card {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+
+  .engineer-icon {
+    margin: 0 auto;
+  }
+
+  .engineer-details {
+    justify-content: center;
+  }
+
+  .hire-engineer-btn {
+    width: 100%;
+  }
+}

--- a/src/components/screens/HireEngineerScreen.tsx
+++ b/src/components/screens/HireEngineerScreen.tsx
@@ -1,0 +1,352 @@
+/**
+ * Hire Engineer Screen - Second gate after ideation
+ * 
+ * User must hire an Engineer to start building.
+ */
+
+import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { useGameStore } from '../../store/gameStore';
+import { EMPLOYEE_TEMPLATES } from '../../types';
+import type { AIProvider } from '../../types';
+import { getApiKey, saveApiKey, type AIProviderKey } from '../../lib/storage/secureStorage';
+import './HireEngineerScreen.css';
+
+function formatMoney(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+// Provider metadata
+const PROVIDER_META: Record<string, { keyPlaceholder: string; keyUrl: string }> = {
+  openai: {
+    keyPlaceholder: 'sk-...',
+    keyUrl: 'https://platform.openai.com/api-keys',
+  },
+  anthropic: {
+    keyPlaceholder: 'sk-ant-...',
+    keyUrl: 'https://console.anthropic.com/settings/keys',
+  },
+  google: {
+    keyPlaceholder: 'API key...',
+    keyUrl: 'https://aistudio.google.com/app/apikey',
+  },
+  groq: {
+    keyPlaceholder: 'gsk_...',
+    keyUrl: 'https://console.groq.com/keys',
+  },
+};
+
+interface ProviderConfig {
+  id: string;
+  name: string;
+  models: string[];
+}
+
+const FALLBACK_PROVIDERS: ProviderConfig[] = [
+  { id: 'openai', name: 'OpenAI', models: ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo'] },
+  { id: 'anthropic', name: 'Anthropic', models: ['claude-sonnet-4-20250514', 'claude-3-5-sonnet-20241022'] },
+  { id: 'google', name: 'Google', models: ['gemini-2.0-flash', 'gemini-1.5-pro'] },
+  { id: 'groq', name: 'Groq', models: ['llama-3.3-70b-versatile'] },
+];
+
+async function fetchProviders(): Promise<ProviderConfig[]> {
+  try {
+    const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+    const response = await fetch(`${apiUrl}/api/models`);
+    if (!response.ok) throw new Error('Failed to fetch models');
+    const data = await response.json();
+    return data.providers || FALLBACK_PROVIDERS;
+  } catch {
+    return FALLBACK_PROVIDERS;
+  }
+}
+
+function HireModal({ 
+  onConfirm, 
+  onCancel 
+}: { 
+  onConfirm: (provider: AIProvider, model: string) => void;
+  onCancel: () => void;
+}) {
+  const [providers, setProviders] = useState<ProviderConfig[]>(FALLBACK_PROVIDERS);
+  const [loading, setLoading] = useState(true);
+  const [selectedProvider, setSelectedProvider] = useState<AIProviderKey>('openai');
+  const [selectedModel, setSelectedModel] = useState('gpt-4o-mini');
+  const [apiKey, setApiKey] = useState('');
+  const [showKey, setShowKey] = useState(false);
+  const [error, setError] = useState('');
+  
+  const engineerTemplate = EMPLOYEE_TEMPLATES.find(t => t.role === 'engineer')!;
+  
+  useEffect(() => {
+    fetchProviders().then((data) => {
+      setProviders(data);
+      if (data.length > 0 && data[0].models.length > 0) {
+        setSelectedProvider(data[0].id as AIProviderKey);
+        setSelectedModel(data[0].models[0]);
+      }
+      setLoading(false);
+    });
+  }, []);
+  
+  const currentProvider = providers.find(p => p.id === selectedProvider) || providers[0];
+  const hasKey = !!getApiKey(selectedProvider);
+  const providerMeta = PROVIDER_META[selectedProvider] || { keyPlaceholder: 'API key...', keyUrl: '#' };
+  
+  const handleProviderChange = (providerId: AIProviderKey) => {
+    setSelectedProvider(providerId);
+    const provider = providers.find(p => p.id === providerId);
+    if (provider && provider.models.length > 0) {
+      setSelectedModel(provider.models[0]);
+    }
+    setApiKey('');
+    setError('');
+  };
+  
+  const handleConfirm = () => {
+    if (!hasKey) {
+      if (!apiKey.trim()) {
+        setError('Please enter your API key');
+        return;
+      }
+      saveApiKey(selectedProvider, apiKey.trim());
+    }
+    onConfirm(selectedProvider as AIProvider, selectedModel);
+  };
+  
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onCancel();
+    }
+  };
+
+  return (
+    <div className="hire-modal-overlay" onClick={handleOverlayClick}>
+      <div className="hire-modal" onClick={e => e.stopPropagation()}>
+        <div className="hire-modal-header">
+          <div className="header-icon">&#9670;</div>
+          <div className="header-text">
+            <h2>Hire Your First Engineer</h2>
+            <p>Choose the AI model that will power your engineer.</p>
+          </div>
+          <button className="close-btn" onClick={onCancel}>&times;</button>
+        </div>
+        
+        <div className="hire-modal-body">
+          {loading ? (
+            <div className="loading-models">Loading available models...</div>
+          ) : (
+            <>
+              <div className="field">
+                <label>AI Provider</label>
+                <div className="provider-options">
+                  {providers.map(provider => {
+                    const hasProviderKey = !!getApiKey(provider.id as AIProviderKey);
+                    return (
+                      <button
+                        key={provider.id}
+                        type="button"
+                        className={`provider-option ${selectedProvider === provider.id ? 'selected' : ''}`}
+                        onClick={() => handleProviderChange(provider.id as AIProviderKey)}
+                      >
+                        <span className="provider-name">{provider.name}</span>
+                        {hasProviderKey && <span className="provider-check">&#10003;</span>}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              
+              <div className="field">
+                <label>Model</label>
+                <select 
+                  value={selectedModel} 
+                  onChange={(e) => setSelectedModel(e.target.value)}
+                >
+                  {currentProvider?.models.map(model => (
+                    <option key={model} value={model}>{model}</option>
+                  ))}
+                </select>
+              </div>
+              
+              {!hasKey && (
+                <div className="field">
+                  <label>
+                    API Key
+                    <span className="required-badge">Required</span>
+                  </label>
+                  <div className="key-input-group">
+                    <input
+                      type={showKey ? 'text' : 'password'}
+                      value={apiKey}
+                      onChange={(e) => setApiKey(e.target.value)}
+                      placeholder={providerMeta.keyPlaceholder}
+                      onKeyDown={(e) => e.key === 'Enter' && handleConfirm()}
+                      autoFocus
+                    />
+                    <button 
+                      type="button" 
+                      className="visibility-toggle"
+                      onClick={() => setShowKey(!showKey)}
+                    >
+                      {showKey ? 'Hide' : 'Show'}
+                    </button>
+                  </div>
+                  <a 
+                    href={providerMeta.keyUrl} 
+                    target="_blank" 
+                    rel="noopener noreferrer"
+                    className="get-key-link"
+                  >
+                    Get {currentProvider?.name} API key &rarr;
+                  </a>
+                </div>
+              )}
+              
+              {hasKey && (
+                <div className="key-configured">
+                  <span className="check-icon">&#10003;</span>
+                  <span>{currentProvider?.name} API key configured</span>
+                </div>
+              )}
+              
+              {error && <div className="error-message">{error}</div>}
+            </>
+          )}
+        </div>
+        
+        <div className="hire-modal-footer">
+          <div className="salary-info">
+            <span className="salary-label">Monthly Salary</span>
+            <span className="salary-amount">{formatMoney(engineerTemplate.baseSalary)}</span>
+          </div>
+          <div className="footer-actions">
+            <button className="btn-cancel" onClick={onCancel}>Cancel</button>
+            <button className="btn-hire" onClick={handleConfirm} disabled={loading}>
+              Hire Engineer
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function HireEngineerScreen() {
+  const money = useGameStore(state => state.money);
+  const tasks = useGameStore(state => state.tasks);
+  const employees = useGameStore(state => state.employees);
+  const hireEmployee = useGameStore(state => state.hireEmployee);
+  const [showModal, setShowModal] = useState(false);
+  
+  const engineerTemplate = EMPLOYEE_TEMPLATES.find(t => t.role === 'engineer')!;
+  const canAfford = money >= engineerTemplate.baseSalary;
+  const pm = employees.find(e => e.role === 'pm');
+
+  const handleConfirmHire = (provider: AIProvider, model: string) => {
+    hireEmployee('engineer', provider, model);
+    setShowModal(false);
+  };
+
+  return (
+    <div className="hire-engineer-screen">
+      <div className="hire-engineer-container">
+        {/* Progress Indicator */}
+        <div className="progress-steps">
+          <div className="step completed">
+            <span className="step-icon">&#10003;</span>
+            <span className="step-label">Idea</span>
+          </div>
+          <div className="step-line completed"></div>
+          <div className="step completed">
+            <span className="step-icon">&#10003;</span>
+            <span className="step-label">PM</span>
+          </div>
+          <div className="step-line completed"></div>
+          <div className="step completed">
+            <span className="step-icon">&#10003;</span>
+            <span className="step-label">Tasks</span>
+          </div>
+          <div className="step-line"></div>
+          <div className="step active">
+            <span className="step-icon">4</span>
+            <span className="step-label">Engineer</span>
+          </div>
+        </div>
+
+        {/* Main Content */}
+        <div className="hire-engineer-content">
+          <h1>Ready to start building!</h1>
+          <p className="subtitle">
+            Your PM has created {tasks.length} tasks. Now hire an engineer to start 
+            executing them.
+          </p>
+
+          {/* Engineer Card */}
+          <div className="engineer-card">
+            <div className="engineer-icon">&#9670;</div>
+            <div className="engineer-info">
+              <h3>Engineer</h3>
+              <p>{engineerTemplate.description}</p>
+              <div className="engineer-details">
+                <span className="engineer-salary">{formatMoney(engineerTemplate.baseSalary)}/mo</span>
+                <span className="engineer-budget">Budget: {formatMoney(money)}</span>
+              </div>
+            </div>
+            <button 
+              className={`hire-engineer-btn ${canAfford ? '' : 'disabled'}`}
+              onClick={() => canAfford && setShowModal(true)}
+              disabled={!canAfford}
+            >
+              {canAfford ? 'Hire Engineer' : 'Not Enough Funds'}
+            </button>
+          </div>
+
+          {/* Task Preview */}
+          <div className="task-preview">
+            <div className="preview-header">
+              <span className="preview-label">Ready Tasks</span>
+              <span className="preview-count">{tasks.length} tasks</span>
+            </div>
+            <div className="preview-tasks">
+              {tasks.slice(0, 3).map(task => (
+                <div key={task.id} className="preview-task">
+                  <span className="task-dot"></span>
+                  <span className="task-title">{task.title}</span>
+                </div>
+              ))}
+              {tasks.length > 3 && (
+                <div className="preview-more">+{tasks.length - 3} more tasks</div>
+              )}
+            </div>
+          </div>
+
+          {/* Team Status */}
+          <div className="team-status">
+            <div className="team-member">
+              <span className="member-icon pm">&#9672;</span>
+              <span className="member-name">{pm?.name || 'PM'}</span>
+              <span className="member-status ready">Ready</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Modal */}
+      {showModal && createPortal(
+        <HireModal
+          onConfirm={handleConfirmHire}
+          onCancel={() => setShowModal(false)}
+        />,
+        document.body
+      )}
+    </div>
+  );
+}
+
+export default HireEngineerScreen;

--- a/src/components/screens/HirePMScreen.css
+++ b/src/components/screens/HirePMScreen.css
@@ -1,0 +1,194 @@
+/* Hire PM Screen - First gate after project creation */
+
+.hire-pm-screen {
+  min-height: 100vh;
+  background: #050508;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.hire-pm-container {
+  width: 100%;
+  max-width: 560px;
+}
+
+/* Project Badge */
+.project-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: rgba(0, 255, 136, 0.08);
+  border: 1px solid rgba(0, 255, 136, 0.2);
+  border-radius: 20px;
+  font-size: 13px;
+  color: #00ff88;
+  margin-bottom: 32px;
+}
+
+.badge-icon {
+  font-size: 14px;
+}
+
+/* Main Content */
+.hire-pm-content h1 {
+  margin: 0 0 12px 0;
+  font-size: 28px;
+  font-weight: 600;
+  color: #e4e4e7;
+  line-height: 1.3;
+}
+
+.hire-pm-content .subtitle {
+  margin: 0 0 32px 0;
+  font-size: 15px;
+  color: #71717a;
+  line-height: 1.6;
+}
+
+/* PM Card */
+.pm-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  margin-bottom: 24px;
+}
+
+.pm-icon {
+  width: 56px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 255, 136, 0.1);
+  border: 1px solid rgba(0, 255, 136, 0.25);
+  border-radius: 14px;
+  font-size: 24px;
+  color: #00ff88;
+  flex-shrink: 0;
+}
+
+.pm-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.pm-info h3 {
+  margin: 0 0 6px 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #e4e4e7;
+}
+
+.pm-info p {
+  margin: 0 0 14px 0;
+  font-size: 14px;
+  color: #71717a;
+  line-height: 1.5;
+}
+
+.pm-details {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.pm-salary {
+  font-size: 16px;
+  font-weight: 600;
+  color: #e4e4e7;
+}
+
+.pm-budget {
+  font-size: 13px;
+  color: #52525b;
+}
+
+.hire-pm-btn {
+  padding: 14px 28px;
+  background: #00ff88;
+  border: none;
+  border-radius: 10px;
+  color: #000;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.hire-pm-btn:hover:not(.disabled) {
+  background: #00cc6a;
+  transform: translateY(-1px);
+}
+
+.hire-pm-btn.disabled {
+  background: rgba(255, 255, 255, 0.1);
+  color: #52525b;
+  cursor: not-allowed;
+}
+
+/* Idea Preview */
+.idea-preview {
+  padding: 20px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+}
+
+.idea-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #52525b;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 10px;
+}
+
+.idea-text {
+  font-size: 14px;
+  color: #a1a1aa;
+  line-height: 1.6;
+  font-style: italic;
+}
+
+/* Modal styles inherit from HireScreen.css */
+
+/* Responsive */
+@media (max-width: 640px) {
+  .hire-pm-screen {
+    padding: 16px;
+    align-items: flex-start;
+    padding-top: 60px;
+  }
+
+  .hire-pm-content h1 {
+    font-size: 22px;
+  }
+
+  .pm-card {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+
+  .pm-icon {
+    margin: 0 auto;
+  }
+
+  .pm-details {
+    justify-content: center;
+  }
+
+  .hire-pm-btn {
+    width: 100%;
+  }
+}

--- a/src/components/screens/HirePMScreen.tsx
+++ b/src/components/screens/HirePMScreen.tsx
@@ -1,0 +1,311 @@
+/**
+ * Hire PM Screen - First gate after project creation
+ * 
+ * User must hire a PM to start the ideation process.
+ */
+
+import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { useGameStore } from '../../store/gameStore';
+import { EMPLOYEE_TEMPLATES } from '../../types';
+import type { AIProvider } from '../../types';
+import { getApiKey, saveApiKey, type AIProviderKey } from '../../lib/storage/secureStorage';
+import './HirePMScreen.css';
+
+function formatMoney(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+// Provider metadata
+const PROVIDER_META: Record<string, { keyPlaceholder: string; keyUrl: string }> = {
+  openai: {
+    keyPlaceholder: 'sk-...',
+    keyUrl: 'https://platform.openai.com/api-keys',
+  },
+  anthropic: {
+    keyPlaceholder: 'sk-ant-...',
+    keyUrl: 'https://console.anthropic.com/settings/keys',
+  },
+  google: {
+    keyPlaceholder: 'API key...',
+    keyUrl: 'https://aistudio.google.com/app/apikey',
+  },
+  groq: {
+    keyPlaceholder: 'gsk_...',
+    keyUrl: 'https://console.groq.com/keys',
+  },
+};
+
+interface ProviderConfig {
+  id: string;
+  name: string;
+  models: string[];
+}
+
+const FALLBACK_PROVIDERS: ProviderConfig[] = [
+  { id: 'openai', name: 'OpenAI', models: ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo'] },
+  { id: 'anthropic', name: 'Anthropic', models: ['claude-sonnet-4-20250514', 'claude-3-5-sonnet-20241022'] },
+  { id: 'google', name: 'Google', models: ['gemini-2.0-flash', 'gemini-1.5-pro'] },
+  { id: 'groq', name: 'Groq', models: ['llama-3.3-70b-versatile'] },
+];
+
+async function fetchProviders(): Promise<ProviderConfig[]> {
+  try {
+    const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+    const response = await fetch(`${apiUrl}/api/models`);
+    if (!response.ok) throw new Error('Failed to fetch models');
+    const data = await response.json();
+    return data.providers || FALLBACK_PROVIDERS;
+  } catch {
+    return FALLBACK_PROVIDERS;
+  }
+}
+
+function HireModal({ 
+  onConfirm, 
+  onCancel 
+}: { 
+  onConfirm: (provider: AIProvider, model: string) => void;
+  onCancel: () => void;
+}) {
+  const [providers, setProviders] = useState<ProviderConfig[]>(FALLBACK_PROVIDERS);
+  const [loading, setLoading] = useState(true);
+  const [selectedProvider, setSelectedProvider] = useState<AIProviderKey>('openai');
+  const [selectedModel, setSelectedModel] = useState('gpt-4o-mini');
+  const [apiKey, setApiKey] = useState('');
+  const [showKey, setShowKey] = useState(false);
+  const [error, setError] = useState('');
+  
+  const pmTemplate = EMPLOYEE_TEMPLATES.find(t => t.role === 'pm')!;
+  
+  useEffect(() => {
+    fetchProviders().then((data) => {
+      setProviders(data);
+      if (data.length > 0 && data[0].models.length > 0) {
+        setSelectedProvider(data[0].id as AIProviderKey);
+        setSelectedModel(data[0].models[0]);
+      }
+      setLoading(false);
+    });
+  }, []);
+  
+  const currentProvider = providers.find(p => p.id === selectedProvider) || providers[0];
+  const hasKey = !!getApiKey(selectedProvider);
+  const providerMeta = PROVIDER_META[selectedProvider] || { keyPlaceholder: 'API key...', keyUrl: '#' };
+  
+  const handleProviderChange = (providerId: AIProviderKey) => {
+    setSelectedProvider(providerId);
+    const provider = providers.find(p => p.id === providerId);
+    if (provider && provider.models.length > 0) {
+      setSelectedModel(provider.models[0]);
+    }
+    setApiKey('');
+    setError('');
+  };
+  
+  const handleConfirm = () => {
+    if (!hasKey) {
+      if (!apiKey.trim()) {
+        setError('Please enter your API key');
+        return;
+      }
+      saveApiKey(selectedProvider, apiKey.trim());
+    }
+    onConfirm(selectedProvider as AIProvider, selectedModel);
+  };
+  
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onCancel();
+    }
+  };
+
+  return (
+    <div className="hire-modal-overlay" onClick={handleOverlayClick}>
+      <div className="hire-modal" onClick={e => e.stopPropagation()}>
+        <div className="hire-modal-header">
+          <div className="header-icon">&#9672;</div>
+          <div className="header-text">
+            <h2>Hire Your First PM</h2>
+            <p>Choose the AI model that will power your product manager.</p>
+          </div>
+          <button className="close-btn" onClick={onCancel}>&times;</button>
+        </div>
+        
+        <div className="hire-modal-body">
+          {loading ? (
+            <div className="loading-models">Loading available models...</div>
+          ) : (
+            <>
+              <div className="field">
+                <label>AI Provider</label>
+                <div className="provider-options">
+                  {providers.map(provider => {
+                    const hasProviderKey = !!getApiKey(provider.id as AIProviderKey);
+                    return (
+                      <button
+                        key={provider.id}
+                        type="button"
+                        className={`provider-option ${selectedProvider === provider.id ? 'selected' : ''}`}
+                        onClick={() => handleProviderChange(provider.id as AIProviderKey)}
+                      >
+                        <span className="provider-name">{provider.name}</span>
+                        {hasProviderKey && <span className="provider-check">&#10003;</span>}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              
+              <div className="field">
+                <label>Model</label>
+                <select 
+                  value={selectedModel} 
+                  onChange={(e) => setSelectedModel(e.target.value)}
+                >
+                  {currentProvider?.models.map(model => (
+                    <option key={model} value={model}>{model}</option>
+                  ))}
+                </select>
+              </div>
+              
+              {!hasKey && (
+                <div className="field">
+                  <label>
+                    API Key
+                    <span className="required-badge">Required</span>
+                  </label>
+                  <div className="key-input-group">
+                    <input
+                      type={showKey ? 'text' : 'password'}
+                      value={apiKey}
+                      onChange={(e) => setApiKey(e.target.value)}
+                      placeholder={providerMeta.keyPlaceholder}
+                      onKeyDown={(e) => e.key === 'Enter' && handleConfirm()}
+                      autoFocus
+                    />
+                    <button 
+                      type="button" 
+                      className="visibility-toggle"
+                      onClick={() => setShowKey(!showKey)}
+                    >
+                      {showKey ? 'Hide' : 'Show'}
+                    </button>
+                  </div>
+                  <a 
+                    href={providerMeta.keyUrl} 
+                    target="_blank" 
+                    rel="noopener noreferrer"
+                    className="get-key-link"
+                  >
+                    Get {currentProvider?.name} API key &rarr;
+                  </a>
+                </div>
+              )}
+              
+              {hasKey && (
+                <div className="key-configured">
+                  <span className="check-icon">&#10003;</span>
+                  <span>{currentProvider?.name} API key configured</span>
+                </div>
+              )}
+              
+              {error && <div className="error-message">{error}</div>}
+            </>
+          )}
+        </div>
+        
+        <div className="hire-modal-footer">
+          <div className="salary-info">
+            <span className="salary-label">Monthly Salary</span>
+            <span className="salary-amount">{formatMoney(pmTemplate.baseSalary)}</span>
+          </div>
+          <div className="footer-actions">
+            <button className="btn-cancel" onClick={onCancel}>Cancel</button>
+            <button className="btn-hire" onClick={handleConfirm} disabled={loading}>
+              Hire PM
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function HirePMScreen() {
+  const project = useGameStore(state => state.project);
+  const money = useGameStore(state => state.money);
+  const hireEmployee = useGameStore(state => state.hireEmployee);
+  const [showModal, setShowModal] = useState(false);
+  
+  const pmTemplate = EMPLOYEE_TEMPLATES.find(t => t.role === 'pm')!;
+  const canAfford = money >= pmTemplate.baseSalary;
+
+  const handleConfirmHire = (provider: AIProvider, model: string) => {
+    hireEmployee('pm', provider, model);
+    setShowModal(false);
+  };
+
+  return (
+    <div className="hire-pm-screen">
+      <div className="hire-pm-container">
+        {/* Project Badge */}
+        <div className="project-badge">
+          <span className="badge-icon">&#9767;</span>
+          <span>{project?.name || 'Your Project'}</span>
+        </div>
+
+        {/* Main Content */}
+        <div className="hire-pm-content">
+          <h1>To start playing, you need a PM</h1>
+          <p className="subtitle">
+            Your Product Manager will break down your vision into actionable tasks 
+            that your team can execute.
+          </p>
+
+          {/* PM Card */}
+          <div className="pm-card">
+            <div className="pm-icon">&#9672;</div>
+            <div className="pm-info">
+              <h3>Product Manager</h3>
+              <p>{pmTemplate.description}</p>
+              <div className="pm-details">
+                <span className="pm-salary">{formatMoney(pmTemplate.baseSalary)}/mo</span>
+                <span className="pm-budget">Budget: {formatMoney(money)}</span>
+              </div>
+            </div>
+            <button 
+              className={`hire-pm-btn ${canAfford ? '' : 'disabled'}`}
+              onClick={() => canAfford && setShowModal(true)}
+              disabled={!canAfford}
+            >
+              {canAfford ? 'Hire PM' : 'Not Enough Funds'}
+            </button>
+          </div>
+
+          {/* Idea Preview */}
+          <div className="idea-preview">
+            <div className="idea-label">Your Vision</div>
+            <div className="idea-text">{project?.idea}</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Modal */}
+      {showModal && createPortal(
+        <HireModal
+          onConfirm={handleConfirmHire}
+          onCancel={() => setShowModal(false)}
+        />,
+        document.body
+      )}
+    </div>
+  );
+}
+
+export default HirePMScreen;

--- a/src/components/screens/IdeateScreen.css
+++ b/src/components/screens/IdeateScreen.css
@@ -1,0 +1,457 @@
+/* Ideate Screen - PM Chat to break down vision */
+
+.ideate-screen {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: #050508;
+}
+
+/* Header */
+.ideate-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  background: rgba(255, 255, 255, 0.02);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.pm-avatar {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 255, 136, 0.12);
+  border: 1px solid rgba(0, 255, 136, 0.25);
+  border-radius: 12px;
+  font-size: 20px;
+  color: #00ff88;
+}
+
+.pm-name .name {
+  display: block;
+  font-size: 15px;
+  font-weight: 600;
+  color: #e4e4e7;
+}
+
+.pm-name .role {
+  font-size: 12px;
+  color: #52525b;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.header-right .task-count {
+  text-align: right;
+}
+
+.header-right .task-count .count {
+  display: block;
+  font-size: 20px;
+  font-weight: 600;
+  color: #00ff88;
+}
+
+.header-right .task-count .label {
+  font-size: 11px;
+  color: #52525b;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.start-building-btn {
+  padding: 12px 24px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: #52525b;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: not-allowed;
+  transition: all 0.15s;
+}
+
+.start-building-btn.ready {
+  background: #00ff88;
+  border-color: #00ff88;
+  color: #000;
+  cursor: pointer;
+}
+
+.start-building-btn.ready:hover {
+  background: #00cc6a;
+}
+
+/* Main Content */
+.ideate-content {
+  display: grid;
+  grid-template-columns: 1fr 380px;
+  flex: 1;
+  min-height: 0;
+}
+
+/* Chat Panel */
+.chat-panel {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.message {
+  display: flex;
+  gap: 12px;
+  max-width: 85%;
+}
+
+.message.user {
+  margin-left: auto;
+  flex-direction: row-reverse;
+}
+
+.message .avatar {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 255, 136, 0.1);
+  border: 1px solid rgba(0, 255, 136, 0.2);
+  border-radius: 10px;
+  font-size: 16px;
+  color: #00ff88;
+  flex-shrink: 0;
+}
+
+.message .bubble {
+  padding: 14px 18px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+}
+
+.message.user .bubble {
+  background: rgba(0, 255, 136, 0.1);
+  border-color: rgba(0, 255, 136, 0.2);
+}
+
+.message .bubble p {
+  margin: 0;
+  font-size: 14px;
+  color: #d4d4d8;
+  line-height: 1.6;
+}
+
+.message .bubble p + p {
+  margin-top: 10px;
+}
+
+/* Thinking Animation */
+.bubble.thinking {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 16px 20px;
+}
+
+.bubble.thinking .dot {
+  width: 8px;
+  height: 8px;
+  background: #71717a;
+  border-radius: 50%;
+  animation: thinking 1.4s ease-in-out infinite;
+}
+
+.bubble.thinking .dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.bubble.thinking .dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes thinking {
+  0%, 60%, 100% {
+    transform: translateY(0);
+    opacity: 0.4;
+  }
+  30% {
+    transform: translateY(-6px);
+    opacity: 1;
+  }
+}
+
+/* Input Area */
+.input-area {
+  display: flex;
+  gap: 12px;
+  padding: 16px 24px;
+  background: rgba(255, 255, 255, 0.02);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.input-area textarea {
+  flex: 1;
+  padding: 14px 18px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  color: #e4e4e7;
+  font-size: 14px;
+  font-family: inherit;
+  resize: none;
+  outline: none;
+}
+
+.input-area textarea:focus {
+  border-color: rgba(0, 255, 136, 0.4);
+}
+
+.input-area textarea::placeholder {
+  color: #3f3f46;
+}
+
+.send-btn {
+  padding: 14px 24px;
+  background: #00ff88;
+  border: none;
+  border-radius: 10px;
+  color: #000;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.send-btn:hover:not(:disabled) {
+  background: #00cc6a;
+}
+
+.send-btn:disabled {
+  background: rgba(255, 255, 255, 0.1);
+  color: #52525b;
+  cursor: not-allowed;
+}
+
+/* Tasks Panel */
+.tasks-panel {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 20px;
+  gap: 24px;
+}
+
+.task-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.section-header h3 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #71717a;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.task-count-badge {
+  padding: 3px 8px;
+  background: rgba(0, 255, 136, 0.1);
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #00ff88;
+}
+
+.add-all-btn {
+  padding: 6px 14px;
+  background: rgba(0, 255, 136, 0.1);
+  border: 1px solid rgba(0, 255, 136, 0.2);
+  border-radius: 6px;
+  color: #00ff88;
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.add-all-btn:hover {
+  background: rgba(0, 255, 136, 0.2);
+}
+
+/* Task List */
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.task-list.added {
+  gap: 8px;
+}
+
+/* Task Card */
+.task-card {
+  padding: 14px 16px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  transition: all 0.15s;
+}
+
+.task-card:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.task-card.added {
+  background: rgba(0, 255, 136, 0.04);
+  border-color: rgba(0, 255, 136, 0.15);
+}
+
+.task-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.task-type {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.task-priority {
+  font-size: 10px;
+  padding: 2px 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  color: #71717a;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.task-card h4 {
+  margin: 0 0 6px 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: #e4e4e7;
+  line-height: 1.4;
+}
+
+.task-card p {
+  margin: 0 0 12px 0;
+  font-size: 12px;
+  color: #71717a;
+  line-height: 1.5;
+}
+
+.task-card.added p {
+  display: none;
+}
+
+.add-task-btn {
+  width: 100%;
+  padding: 8px 12px;
+  background: transparent;
+  border: 1px solid rgba(0, 255, 136, 0.25);
+  border-radius: 6px;
+  color: #00ff88;
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.add-task-btn:hover {
+  background: rgba(0, 255, 136, 0.1);
+}
+
+/* Empty State */
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  color: #52525b;
+  font-size: 14px;
+  text-align: center;
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+  .ideate-content {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr auto;
+  }
+
+  .chat-panel {
+    border-right: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    max-height: 60vh;
+  }
+
+  .tasks-panel {
+    max-height: 40vh;
+  }
+}
+
+@media (max-width: 640px) {
+  .ideate-header {
+    padding: 12px 16px;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .header-right {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .messages {
+    padding: 16px;
+  }
+
+  .input-area {
+    padding: 12px 16px;
+  }
+
+  .tasks-panel {
+    padding: 16px;
+  }
+}

--- a/src/components/screens/IdeateScreen.tsx
+++ b/src/components/screens/IdeateScreen.tsx
@@ -1,0 +1,398 @@
+/**
+ * Ideate Screen - Chat with PM to break down vision into tasks
+ * 
+ * This is the ideation phase where the PM helps break down the project
+ * vision into actionable tasks before development starts.
+ */
+
+import { useState, useRef, useEffect } from 'react';
+import { useGameStore } from '../../store/gameStore';
+import type { TaskType, TaskPriority } from '../../types';
+import { aiService } from '../../lib/ai';
+import './IdeateScreen.css';
+
+interface ChatMessage {
+  id: string;
+  role: 'user' | 'pm';
+  content: string;
+  timestamp: number;
+}
+
+interface SuggestedTask {
+  title: string;
+  description: string;
+  type: TaskType;
+  priority: TaskPriority;
+  estimatedTicks: number;
+}
+
+export function IdeateScreen() {
+  const project = useGameStore(state => state.project);
+  const employees = useGameStore(state => state.employees);
+  const tasks = useGameStore(state => state.tasks);
+  const createTask = useGameStore(state => state.createTask);
+  const completeIdeation = useGameStore(state => state.completeIdeation);
+  const aiSettings = useGameStore(state => state.aiSettings);
+  
+  const pm = employees.find(e => e.role === 'pm');
+  
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [isThinking, setIsThinking] = useState(false);
+  const [suggestedTasks, setSuggestedTasks] = useState<SuggestedTask[]>([]);
+  const [hasStarted, setHasStarted] = useState(false);
+  
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  // Scroll to bottom when messages change
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  // Start the conversation when component mounts
+  useEffect(() => {
+    if (!hasStarted && pm && project) {
+      setHasStarted(true);
+      startConversation();
+    }
+  }, [hasStarted, pm, project]);
+
+  const startConversation = async () => {
+    if (!pm || !project) return;
+    
+    // Add initial PM greeting
+    const greeting: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'pm',
+      content: `Hi! I'm ${pm.name}, your Product Manager. I've reviewed your vision:\n\n"${project.idea}"\n\nThis sounds exciting! Let me help you break this down into actionable tasks. What aspect should we tackle first? Or I can suggest a breakdown to get us started.`,
+      timestamp: Date.now(),
+    };
+    setMessages([greeting]);
+    
+    // Auto-generate initial task suggestions
+    await generateTaskSuggestions();
+  };
+
+  const generateTaskSuggestions = async () => {
+    if (!project || !pm) return;
+    
+    setIsThinking(true);
+    try {
+      // Use AI to generate task breakdown
+      if (aiSettings.enabled) {
+        const existingTitles = tasks.map(t => t.title);
+        const newTasks = await aiService.pmGenerateTasks(
+          project.idea,
+          existingTitles,
+          { engineers: 0, designers: 0, marketers: 0 }
+        );
+        setSuggestedTasks(newTasks);
+      } else {
+        // Fallback: Generate mock tasks based on project type
+        const mockTasks = generateMockTasks(project.projectType, project.idea);
+        setSuggestedTasks(mockTasks);
+      }
+    } catch (error) {
+      console.error('Failed to generate tasks:', error);
+      // Use fallback
+      const mockTasks = generateMockTasks(project?.projectType || 'frontend', project?.idea || '');
+      setSuggestedTasks(mockTasks);
+    }
+    setIsThinking(false);
+  };
+
+  const generateMockTasks = (_projectType: string, idea: string): SuggestedTask[] => {
+    const baseTasks: SuggestedTask[] = [
+      {
+        title: 'Project setup and configuration',
+        description: 'Initialize project structure, configure build tools, and set up development environment.',
+        type: 'infrastructure',
+        priority: 'high',
+        estimatedTicks: 60,
+      },
+      {
+        title: 'Core data models',
+        description: 'Define the main data structures and types for the application.',
+        type: 'feature',
+        priority: 'high',
+        estimatedTicks: 80,
+      },
+      {
+        title: 'User interface design',
+        description: 'Create the main UI components and layout structure.',
+        type: 'design',
+        priority: 'medium',
+        estimatedTicks: 100,
+      },
+      {
+        title: 'Main feature implementation',
+        description: `Implement the core functionality: ${idea.slice(0, 50)}...`,
+        type: 'feature',
+        priority: 'high',
+        estimatedTicks: 150,
+      },
+      {
+        title: 'Testing and validation',
+        description: 'Write tests and validate core functionality works as expected.',
+        type: 'infrastructure',
+        priority: 'medium',
+        estimatedTicks: 80,
+      },
+    ];
+    
+    return baseTasks;
+  };
+
+  const handleSendMessage = async () => {
+    if (!input.trim() || isThinking) return;
+    
+    const userMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'user',
+      content: input.trim(),
+      timestamp: Date.now(),
+    };
+    
+    setMessages(prev => [...prev, userMessage]);
+    setInput('');
+    setIsThinking(true);
+    
+    // Generate PM response
+    setTimeout(() => {
+      const pmResponse: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: 'pm',
+        content: generatePMResponse(input.trim()),
+        timestamp: Date.now(),
+      };
+      setMessages(prev => [...prev, pmResponse]);
+      setIsThinking(false);
+    }, 1000 + Math.random() * 1000);
+  };
+
+  const generatePMResponse = (userInput: string): string => {
+    const lower = userInput.toLowerCase();
+    
+    if (lower.includes('more') || lower.includes('add') || lower.includes('another')) {
+      return "I'll add more tasks to the backlog. Based on our discussion, what specific area would you like me to focus on?";
+    }
+    
+    if (lower.includes('ready') || lower.includes('done') || lower.includes('start') || lower.includes('build')) {
+      return "Great! The task breakdown looks solid. Add the tasks you want to work on, and when you're ready, click 'Start Building' to hire an engineer and begin development!";
+    }
+    
+    if (lower.includes('change') || lower.includes('modify') || lower.includes('update')) {
+      return "Sure! You can remove tasks from the list or let me know what changes you'd like, and I'll regenerate suggestions.";
+    }
+    
+    return `Good point about "${userInput.slice(0, 30)}...". I've noted that. Should I adjust the task priorities or add specific tasks for this?`;
+  };
+
+  const handleAddTask = (task: SuggestedTask) => {
+    createTask({
+      title: task.title,
+      description: task.description,
+      type: task.type,
+      priority: task.priority,
+      status: 'backlog',
+      assigneeId: null,
+      estimatedTicks: task.estimatedTicks,
+    });
+    
+    // Remove from suggestions
+    setSuggestedTasks(prev => prev.filter(t => t.title !== task.title));
+    
+    // Add confirmation message
+    const confirmMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'pm',
+      content: `Added "${task.title}" to the backlog.`,
+      timestamp: Date.now(),
+    };
+    setMessages(prev => [...prev, confirmMessage]);
+  };
+
+  const handleAddAllTasks = () => {
+    suggestedTasks.forEach(task => {
+      createTask({
+        title: task.title,
+        description: task.description,
+        type: task.type,
+        priority: task.priority,
+        status: 'backlog',
+        assigneeId: null,
+        estimatedTicks: task.estimatedTicks,
+      });
+    });
+    
+    setSuggestedTasks([]);
+    
+    const confirmMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'pm',
+      content: `Added ${suggestedTasks.length} tasks to the backlog. Looking good! When you're ready, click "Start Building" to hire an engineer.`,
+      timestamp: Date.now(),
+    };
+    setMessages(prev => [...prev, confirmMessage]);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSendMessage();
+    }
+  };
+
+  const taskTypeColors: Record<TaskType, string> = {
+    feature: '#00ff88',
+    bug: '#ef4444',
+    design: '#a855f7',
+    infrastructure: '#3b82f6',
+  };
+
+  return (
+    <div className="ideate-screen">
+      {/* Header */}
+      <header className="ideate-header">
+        <div className="header-left">
+          <div className="pm-avatar">&#9672;</div>
+          <div className="pm-name">
+            <span className="name">{pm?.name || 'PM'}</span>
+            <span className="role">Product Manager</span>
+          </div>
+        </div>
+        <div className="header-right">
+          <div className="task-count">
+            <span className="count">{tasks.length}</span>
+            <span className="label">Tasks</span>
+          </div>
+          <button 
+            className={`start-building-btn ${tasks.length > 0 ? 'ready' : ''}`}
+            onClick={completeIdeation}
+            disabled={tasks.length === 0}
+          >
+            Start Building &rarr;
+          </button>
+        </div>
+      </header>
+
+      {/* Main Content */}
+      <div className="ideate-content">
+        {/* Chat Panel */}
+        <div className="chat-panel">
+          <div className="messages">
+            {messages.map(msg => (
+              <div key={msg.id} className={`message ${msg.role}`}>
+                {msg.role === 'pm' && <div className="avatar">&#9672;</div>}
+                <div className="bubble">
+                  {msg.content.split('\n').map((line, i) => (
+                    <p key={i}>{line}</p>
+                  ))}
+                </div>
+              </div>
+            ))}
+            {isThinking && (
+              <div className="message pm">
+                <div className="avatar">&#9672;</div>
+                <div className="bubble thinking">
+                  <span className="dot"></span>
+                  <span className="dot"></span>
+                  <span className="dot"></span>
+                </div>
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+          
+          <div className="input-area">
+            <textarea
+              ref={inputRef}
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Discuss your vision with your PM..."
+              rows={1}
+            />
+            <button 
+              className="send-btn" 
+              onClick={handleSendMessage}
+              disabled={!input.trim() || isThinking}
+            >
+              Send
+            </button>
+          </div>
+        </div>
+
+        {/* Tasks Panel */}
+        <div className="tasks-panel">
+          {/* Suggested Tasks */}
+          {suggestedTasks.length > 0 && (
+            <div className="task-section">
+              <div className="section-header">
+                <h3>Suggested Tasks</h3>
+                <button className="add-all-btn" onClick={handleAddAllTasks}>
+                  Add All
+                </button>
+              </div>
+              <div className="task-list">
+                {suggestedTasks.map((task, i) => (
+                  <div key={i} className="task-card suggested">
+                    <div className="task-header">
+                      <span 
+                        className="task-type"
+                        style={{ color: taskTypeColors[task.type] }}
+                      >
+                        {task.type}
+                      </span>
+                      <span className="task-priority">{task.priority}</span>
+                    </div>
+                    <h4>{task.title}</h4>
+                    <p>{task.description}</p>
+                    <button className="add-task-btn" onClick={() => handleAddTask(task)}>
+                      + Add Task
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Added Tasks */}
+          {tasks.length > 0 && (
+            <div className="task-section">
+              <div className="section-header">
+                <h3>Backlog</h3>
+                <span className="task-count-badge">{tasks.length}</span>
+              </div>
+              <div className="task-list added">
+                {tasks.map((task) => (
+                  <div key={task.id} className="task-card added">
+                    <div className="task-header">
+                      <span 
+                        className="task-type"
+                        style={{ color: taskTypeColors[task.type] }}
+                      >
+                        {task.type}
+                      </span>
+                      <span className="task-priority">{task.priority}</span>
+                    </div>
+                    <h4>{task.title}</h4>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {suggestedTasks.length === 0 && tasks.length === 0 && (
+            <div className="empty-state">
+              <p>Chat with your PM to generate task suggestions</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default IdeateScreen;

--- a/src/components/screens/StartScreen.tsx
+++ b/src/components/screens/StartScreen.tsx
@@ -50,8 +50,8 @@ export function StartScreen() {
     e?.preventDefault();
     if (idea.trim().length >= 10) {
       startProject(idea.trim());
-      // Navigate to the game after starting the project
-      navigate('/');
+      // Navigate to onboarding flow (hire PM first)
+      navigate('/play/onboarding');
     }
   };
 

--- a/src/components/screens/index.ts
+++ b/src/components/screens/index.ts
@@ -3,6 +3,13 @@ export { LandingPage } from './LandingPage';
 export { AuthScreen } from './AuthScreen';
 export { StartScreen } from './StartScreen';
 export { ProjectsScreen } from './ProjectsScreen';
+
+// Onboarding Flow Screens
+export { HirePMScreen } from './HirePMScreen';        // First gate: hire PM
+export { IdeateScreen } from './IdeateScreen';        // PM chat to break down vision
+export { HireEngineerScreen } from './HireEngineerScreen'; // Second gate: hire engineer
+
+// Main Game Screens
 export { RTSView } from './RTSView';          // Isometric RTS view - Civ/Warcraft style
 export { CampusScreen } from './CampusScreen'; // Isometric campus view - Phaser 3
 export { DashboardScreen } from './DashboardScreen';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -251,12 +251,23 @@ export interface SavedProject {
   tasksCompleted: number;
 }
 
+// Game Flow Phase - tracks the onboarding/gameplay progression
+export type GamePhase = 
+  | 'new'           // Just started, no project yet
+  | 'hire_pm'       // Project created, need to hire PM first
+  | 'ideate'        // PM hired, breaking down idea into tasks
+  | 'hire_engineer' // Ideation done, need engineer to start building
+  | 'playing';      // Full game mode - all core roles in place
+
 // Game State
 export type GameScreen = 
   | 'landing'      // Landing page for new users
   | 'auth'         // Login/signup
   | 'start'        // Start new project
   | 'projects'     // Project list - continue a saved project
+  | 'hire_pm'      // First gate: hire a PM to start
+  | 'ideate'       // Chat with PM to break down vision into tasks
+  | 'hire_engineer'// Second gate: hire engineer to start building
   | 'rts'          // Isometric RTS view (Civ/Warcraft style) - NEW DEFAULT
   | 'campus'       // Isometric campus view (Phaser 3) - Visual startup HQ
   | 'dashboard'    // Clean split-view
@@ -343,6 +354,7 @@ export interface AISettings {
 export interface GameState {
   // Meta
   screen: GameScreen;
+  phase: GamePhase; // Current game flow phase
   tick: number; // Game time unit
   startedAt: Date;
   
@@ -571,6 +583,7 @@ export const EVENT_DEFINITIONS: Omit<GameEvent, 'id' | 'effect'>[] = [
 export interface GameActions {
   // Navigation
   setScreen: (screen: GameScreen) => void;
+  setPhase: (phase: GamePhase) => void;
   
   // Game Control
   gameTick: () => void;
@@ -578,6 +591,9 @@ export interface GameActions {
   
   // Project
   startProject: (idea: string) => void;
+  
+  // Ideation Phase
+  completeIdeation: () => void; // Called when PM finishes breaking down vision
   
   // Team
   hireEmployee: (role: EmployeeRole, aiProvider?: AIProvider, aiModel?: string) => void;


### PR DESCRIPTION
## Summary

This PR implements a new onboarding flow that guides users through the game setup in a logical progression:

1. **User enters idea** (or imports from GitHub) on StartScreen
2. **Hire PM Gate** - User must hire a PM first to start playing
3. **Ideate Mode** - Chat with PM to break down vision into actionable tasks  
4. **Hire Engineer Gate** - After tasks are created, hire an engineer
5. **Playing Phase** - Full game mode begins

## Changes

### New Files
- `HirePMScreen.tsx/.css` - First gate screen after project creation
- `IdeateScreen.tsx/.css` - PM chat interface for task breakdown with AI suggestions
- `HireEngineerScreen.tsx/.css` - Second gate screen before gameplay

### Modified Files
- `src/types/index.ts` - Added `GamePhase` type and phase fields
- `src/store/gameStore.ts` - Added phase management, `setPhase()`, `completeIdeation()`, automatic phase transitions
- `src/components/screens/index.ts` - Export new screens
- `src/components/screens/StartScreen.tsx` - Navigate to onboarding after project creation
- `src/App.tsx` - Added `PhaseRouter` and `PlayingPhaseGuard` for phase-based routing

## Key Features

- Phase-based routing with automatic transitions
- Persistent game phase (saves/restores on reload)
- Chat-like ideation interface with AI-powered task suggestions
- Progress indicators showing onboarding steps

## Note
There are some pre-existing build errors in the codebase from the main branch that are unrelated to this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a guided onboarding sequence before gameplay, with persisted phase state and guarded navigation.
> 
> - Adds `GamePhase` and phase management in store: `phase` field, `setPhase()`, `completeIdeation()`, auto-transitions on hiring; persists phase and sets UI on rehydrate; game runs only in `playing`
> - New onboarding screens: `HirePMScreen`, `IdeateScreen` (PM chat + AI task suggestions), `HireEngineerScreen` with provider/model selection modals and styles
> - Routing updates: new `/play/onboarding/*` with `PhaseRouter`; `PlayingPhaseGuard` restricts `/play` to `playing` phase; `StartScreen` now navigates to onboarding after project creation
> - Minor: exports added in `components/screens/index.ts`; `App.tsx` integrated guards and routes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37072e6f28564fe54f38148822f4e2e2ac7374ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->